### PR TITLE
Fix equality behavior for SunPhaseName

### DIFF
--- a/SunCalcNet.Tests/SunCalcTests.cs
+++ b/SunCalcNet.Tests/SunCalcTests.cs
@@ -56,7 +56,7 @@ namespace SunCalcNet.Tests
             //Assert
             foreach (var testSunPhase in testData)
             {
-                var sunPhaseValue = sunPhases.First(x => x.Name.Value == testSunPhase.Name.Value);
+                var sunPhaseValue = sunPhases.First(x => x.Name == testSunPhase.Name);
 
                 var testDataPhaseTime = testSunPhase.PhaseTime.ToString("yyyy-MM-dd hh:mm:ss");
                 var sunPhaseTime = sunPhaseValue.PhaseTime.ToString("yyyy-MM-dd hh:mm:ss");
@@ -102,7 +102,7 @@ namespace SunCalcNet.Tests
             //Assert
             foreach (var testSunPhase in heightTestData)
             {
-                var sunPhaseValue = sunPhases.First(x => x.Name.Value == testSunPhase.Name.Value);
+                var sunPhaseValue = sunPhases.First(x => x.Name == testSunPhase.Name);
 
                 var testDataPhaseTime = testSunPhase.PhaseTime.ToString("yyyy-MM-dd hh:mm:ss");
                 var sunPhaseTime = sunPhaseValue.PhaseTime.ToString("yyyy-MM-dd hh:mm:ss");

--- a/SunCalcNet/Model/SunPhaseAngle.cs
+++ b/SunCalcNet/Model/SunPhaseAngle.cs
@@ -4,8 +4,8 @@ using System.Collections.Generic;
 namespace SunCalcNet.Model
 {
     [Serializable]
-    public class SunPhaseName
-    {
+    public class SunPhaseName : IEquatable<SunPhaseName>
+	{
         private SunPhaseName(string value)
         {
             Value = value;
@@ -31,6 +31,31 @@ namespace SunCalcNet.Model
         public override string ToString()
         {
             return Value;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is SunPhaseName other && Equals(other);
+        }
+
+        public bool Equals(SunPhaseName other)
+        {
+            return other != null && Value == other.Value;
+        }
+
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+
+        public static bool operator ==(SunPhaseName left, SunPhaseName right)
+        {
+            return left is null ? right is null : left.Equals(right);
+        }
+
+        public static bool operator !=(SunPhaseName left, SunPhaseName right)
+        {
+            return !(left == right);
         }
     }
 


### PR DESCRIPTION
This PR adds proper equality support to SunPhaseName by implementing IEquatable<SunPhaseName>, overriding Equals(), GetHashCode(), and the == / != operators. This enables correct use of LINQ and comparisons in consuming libraries like:

`if (phase.Name == SunPhaseName.Sunrise) { ... }`
Without this change, only .Value comparisons work, which is unexpected and error-prone.